### PR TITLE
Adapt to new Just versioning

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -58,7 +58,7 @@ download_release() {
     platform=$(get_platform)
 
     # TODO: Adapt the release URL convention for just
-    url="$GH_REPO/releases/download/v${version}/just-v${version}-${platform}.tar.gz"
+    url="$GH_REPO/releases/download/${version}/just-${version}-${platform}.tar.gz"
 
     echo "* Downloading just release $version..."
     curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
@@ -76,7 +76,7 @@ install_version() {
     fi
 
     # TODO: Adapt this to proper extension and adapt extracting strategy.
-    local release_file="$install_path/just-v${version}-${platform}.tar.gz"
+    local release_file="$install_path/just-${version}-${platform}.tar.gz"
     local install_path_bin="${install_path}/bin"
     (
         mkdir -p "$install_path_bin"


### PR DESCRIPTION
Since 0.9.5 the Just releases are no longer prefixed with a "v" as can be seen here: https://github.com/casey/just/releases. Can be handled much nicer and more robust, but it works for now (same way as before) 