### PR TITLE
fix: remove 'v' from the release download url

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -58,7 +58,7 @@ download_release() {
     platform=$(get_platform)
 
     # TODO: Adapt the release URL convention for just
-    url="$GH_REPO/releases/download/v${version}/just-v${version}-${platform}.tar.gz"
+    url="$GH_REPO/releases/download/${version}/just-${version}-${platform}.tar.gz"
 
     echo "* Downloading just release $version..."
     curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"


### PR DESCRIPTION
Tried installing just via asdf, got 404 error
```
* Downloading just release 1.1.3...
curl: (22) The requested URL returned error: 404 
asdf-just: Could not download https://github.com/casey/just/releases/download/v1.1.3/just-v1.1.3-x86_64-unknown-linux-musl.tar.gz
asdf-just: An error ocurred while installing just 1.1.3.
```
the correct url is https://github.com/casey/just/releases/download/1.1.3/just-1.1.3-x86_64-unknown-linux-musl.tar.gz